### PR TITLE
Changes that include fetch() and Decode()

### DIFF
--- a/MIPS_CPU.c
+++ b/MIPS_CPU.c
@@ -5,10 +5,13 @@
 #include "supportingFiles/rTypeOperation.h"
 
 //global register array
-const char *register_number[32] = {"R0","R1","R2","R3","R4","R5","R6","R7","R8","R9","R10","R11","R12","R13","R14","R15","R16","R17","R18","R19","R20","R21","R22","R23","R24","R25","R26","R27","R28","R29","R30","R31"};
-const char *register_name[32] = {"zero","at","v0","v1","a0","a1","a2","a3","t0","t1","t2","t3","t4","t5","t6","t7","s0","s1","s2","s3","s4","s5","s6","s7","t8","t9","k0","k1","gp","sp","fp","ra"};
+const char *registerfile[32] = {"R0","R1","R2","R3","R4","R5","R6","R7","R8","R9","R10","R11","R12","R13","R14","R15","R16","R17","R18","R19","R20","R21","R22","R23","R24","R25","R26","R27","R28","R29","R30","R31"};
+const char *register_name[32] = {"$zero","$at","$v0","$v1","$a0","$a1","$a2","$a3","$t0","$t1","$t2","$t3","$t4","$t5","$t6","$t7","$s0","$s1","$s2","$s3","$s4","$s5","$s6","$s7","$t8","$t9","$k0","$k1","$gp","$sp","$fp","$ra"};
+
 
 int pc = 0; //pc counter to be incremented
+
+
 
 
 int Rtype(int code[]){              //Uriel Montes
@@ -34,13 +37,13 @@ subu    10 0011 (funct)
         operation(funct);
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         int rd = FiveConvert(code[16], code[17], code[18],code[19],code[20]);
-        printf("Rd: %s (%s)\n", register_name[rd], register_number[rd]);
+        printf("Rd: %s (%s)\n", register_name[rd], registerfile[rd]);
 
         int shamt = FiveConvert(code[21], code[22], code[23],code[24],code[25]);
         printf("Shamt: %d\n", shamt);
@@ -85,10 +88,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): addi\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -115,10 +118,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): addiu");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -144,10 +147,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): andi\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -173,10 +176,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): beq\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -202,10 +205,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): bne\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -231,10 +234,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): lbu\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -260,10 +263,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): lhu\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -289,10 +292,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): ll\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -318,10 +321,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): lui\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -347,10 +350,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): lw\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -376,10 +379,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): ori\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -405,10 +408,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): slti\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -434,10 +437,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): sltiu\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -463,10 +466,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): sb\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -492,10 +495,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): sc\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -521,10 +524,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): sh\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -550,10 +553,10 @@ int Itype(int code[]){      //John Villalvazo
         printf("Operation (Opcode): sw\n");
 
         int rs = FiveConvert(code[6], code[7], code[8],code[9],code[10]);
-        printf("Rs: %s (%s)\n", register_name[rs], register_number[rs]);
+        printf("Rs: %s (%s)\n", register_name[rs], registerfile[rs]);
 
         int rt = FiveConvert(code[11], code[12], code[13],code[14],code[15]);
-        printf("Rt: %s (%s)\n", register_name[rt], register_number[rt]);
+        printf("Rt: %s (%s)\n", register_name[rt], registerfile[rt]);
 
         if (code[16] == 0) {
             int immediate = sixteenConverter(code[16], code[17], code[18],code[19],code[20],code[21], code[22], code[23],code[24],code[25],code[26], code[27], code[28],code[29],code[30], code[31]);
@@ -609,13 +612,7 @@ jal     000010
     return 0;
 }
 
-// void fetch(){
-
-
-
-// }
-
-int getInput(FILE *ptr, char var[32], int code[32]){
+int fetch(FILE *ptr, char var[32], int code[32]){
     // int i = 0;
      if ( ptr == NULL ){
         printf( "sample_binary.c file failed to open." ) ;
@@ -630,16 +627,25 @@ int getInput(FILE *ptr, char var[32], int code[32]){
 
                 printf("%s", var);
                 int next_pc = pc + 4;
-                
+
+                /* ! We will discuss later but the branch target and jump target addresses
+                will be updated by the other functions to “branch_target” and “jump_target”. So, add a logic
+                in this Fetch() function that copies one of the three possible pc values (next_pc,
+                branch_target, and jump_target) to pc variable. This updated pc value will be used for the
+                next instruction fetch
+                */
+               
+                //! need to find the sign-extension within the Immediate type
+
                 for (int i = 0; i < 32; i++){
                     code[i] = var[i] - '0'; //convert the char into a digit
                 }
 
                 printf("\n");
 
-                Rtype(code);
-                Itype(code);
-                Jtype(code);
+                Rtype(code);    //these is the decode() functions that are embedded within fetch()
+                Itype(code);    //these is the decode() functions that are embedded within fetch()
+                Jtype(code);    //these is the decode() functions that are embedded within fetch()
            
             }
 
@@ -654,6 +660,9 @@ int getInput(FILE *ptr, char var[32], int code[32]){
 }
 
 
+int ALU(){
+    
+}
 
 int main(int argc, char** argv){
 
@@ -664,7 +673,7 @@ int main(int argc, char** argv){
     int code[32];   //making space available
     char var[32];   //taking the instruction as a char then breaking it up into its individual numbers
 
-    getInput(ptr, var, code);
+    fetch(ptr, var, code);
 
     return 0;
 }


### PR DESCRIPTION
Functions requested by documentation. Where decode is split into to their own types (R, I, J) and the I type instructions already been embedded into the fetch function that used .h files that have other helping functions solve for the opcode and other registers. I-type also sign-extension  working within its own section and returns this offset value in the immediate value. (**Note: this split was done within our HW3 and thus carried it over into the main project rather than changing our working code.**)

Fetch() was separated from the main function and simply makes a single function call to the external function and passes the pointer that is reading the data from our given file, the array of characters called var[32] holding each instruction as well as a array of integers called code[32] that makes space for the code of each register.